### PR TITLE
Point at existing upstream vagrant box for Debian Jessie.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "jessie"
-  config.vm.box_url = "https://dl.dropboxusercontent.com/u/2060057/package.box"
+  config.vm.box = "debian/jessie64"
 
   config.vm.synced_folder "../", "/jepsen"
 


### PR DESCRIPTION
It's unclear that the custom box hosted on dropbox has anything
special which is necessary, and this works for me.

One advantage of this is, if one has other vagrant boxes using
"debian/jessie64", no additional download / delay is necessary
to 'vagrant up' here.
